### PR TITLE
Improve code snippets outlook

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -6,8 +6,13 @@
   -moz-box-shadow: 3px 3px rgba(0,0,0,0.1);
   -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
   box-shadow: 3px 3px rgba(0,0,0,0.1);
-  margin: 20px 0 20px 0;
+  margin: 0px 0 0px 0;
   overflow: auto;
+}
+
+.highlight .highlight {
+  border: none;
+  box-shadow: none;
 }
 
 code {


### PR DESCRIPTION
Code snippets look like two concentric boxes, since they are rendered as a highlight div inside another.

This PR works that around, making code snippets look like a single box.

Addresses last point of, and closes #13.