### PR TITLE
Fix table of content links

### DIFF
--- a/_posts/2017-11-08-Shell-scripting-adventures-part-1.md
+++ b/_posts/2017-11-08-Shell-scripting-adventures-part-1.md
@@ -9,15 +9,15 @@ This is the Part 1 (of 5) of the shell scripting adventures, introduced in the [
 
 The following subjects are described in this part:
 
-- [Associative arrays (hash maps)](Shell-scripting-adventures-part-1#associative-arrays-hash-maps)
-- [ANSI-C quoting](Shell-scripting-adventures-part-1#ansi-c-quoting)
-- [Escape strings](Shell-scripting-adventures-part-1#escape-strings)
-- [Expand strings into separate options](Shell-scripting-adventures-part-1#expand-strings-into-separate-options)
-- [Regular expressions matching](Shell-scripting-adventures-part-1#regular-expressions-matching)
-- [Find a filename's basename](Shell-scripting-adventures-part-1#find-a-filenames-basename)
-- [Replace the extension of a filename](Shell-scripting-adventures-part-1#replace-the-extension-of-a-filename)
-- [Cycle a multi-line variable](Shell-scripting-adventures-part-1#cycle-a-multi-line-variable)
-- [Heredoc](Shell-scripting-adventures-part-1#heredoc)
+- [Associative arrays (hash maps)](/Shell-scripting-adventures-part-1#associative-arrays-hash-maps)
+- [ANSI-C quoting](/Shell-scripting-adventures-part-1#ansi-c-quoting)
+- [Escape strings](/Shell-scripting-adventures-part-1#escape-strings)
+- [Expand strings into separate options](/Shell-scripting-adventures-part-1#expand-strings-into-separate-options)
+- [Regular expressions matching](/Shell-scripting-adventures-part-1#regular-expressions-matching)
+- [Find a filename's basename](/Shell-scripting-adventures-part-1#find-a-filenames-basename)
+- [Replace the extension of a filename](/Shell-scripting-adventures-part-1#replace-the-extension-of-a-filename)
+- [Cycle a multi-line variable](/Shell-scripting-adventures-part-1#cycle-a-multi-line-variable)
+- [Heredoc](/Shell-scripting-adventures-part-1#heredoc)
 
 The examples are taken from my [RPi VPN Router project installation script](https://github.com/saveriomiroddi/rpi_vpn_router/blob/master/install_vpn_router.sh).
 

--- a/_posts/2017-11-22-Shell-scripting-adventures-part-2.md
+++ b/_posts/2017-11-22-Shell-scripting-adventures-part-2.md
@@ -9,20 +9,20 @@ This is the Part 2 (of 5) of the shell scripting adventures, introduced in the [
 
 The following subjects are described in this part:
 
-- [Awk/sed/perl considerations](Shell-scripting-adventures-part-2#awksedperl-considerations)
-- [Perl text processing](Shell-scripting-adventures-part-2#perl-text-processing)
-  - [Regex modifiers](Shell-scripting-adventures-part-2#regex-modifiers)
-  - [Replace multiple lines](Shell-scripting-adventures-part-2#replace-multiple-lines)
-    - [`m` modifier](Shell-scripting-adventures-part-2#m-modifier)
-    - [`s` modifier](Shell-scripting-adventures-part-2#s-modifier)
-  - [Isolating ambiguous group references](Shell-scripting-adventures-part-2#isolating-ambiguous-group-references)
-  - [Printing a matching group (of matching lines)](Shell-scripting-adventures-part-2#printing-a-matching-group-of-matching-lines)
-- [Awk text processing](Shell-scripting-adventures-part-2#awk-text-processing)
-- [Progress bars processing with awk (and stdbuf)](Shell-scripting-adventures-part-2#progress-bars-processing-with-awk-and-stdbuf)
-  - [Processing single-line progress outputs](Shell-scripting-adventures-part-2#processing-single-line-progress-outputs)
-  - [Working around the buffering](Shell-scripting-adventures-part-2#working-around-the-buffering)
-  - [Streams processing](Shell-scripting-adventures-part-2#streams-processing)
-  - [Putting things together](Shell-scripting-adventures-part-2#putting-things-together)
+- [Awk/sed/perl considerations](/Shell-scripting-adventures-part-2#awksedperl-considerations)
+- [Perl text processing](/Shell-scripting-adventures-part-2#perl-text-processing)
+  - [Regex modifiers](/Shell-scripting-adventures-part-2#regex-modifiers)
+  - [Replace multiple lines](/Shell-scripting-adventures-part-2#replace-multiple-lines)
+    - [`m` modifier](/Shell-scripting-adventures-part-2#m-modifier)
+    - [`s` modifier](/Shell-scripting-adventures-part-2#s-modifier)
+  - [Isolating ambiguous group references](/Shell-scripting-adventures-part-2#isolating-ambiguous-group-references)
+  - [Printing a matching group (of matching lines)](/Shell-scripting-adventures-part-2#printing-a-matching-group-of-matching-lines)
+- [Awk text processing](/Shell-scripting-adventures-part-2#awk-text-processing)
+- [Progress bars processing with awk (and stdbuf)](/Shell-scripting-adventures-part-2#progress-bars-processing-with-awk-and-stdbuf)
+  - [Processing single-line progress outputs](/Shell-scripting-adventures-part-2#processing-single-line-progress-outputs)
+  - [Working around the buffering](/Shell-scripting-adventures-part-2#working-around-the-buffering)
+  - [Streams processing](/Shell-scripting-adventures-part-2#streams-processing)
+  - [Putting things together](/Shell-scripting-adventures-part-2#putting-things-together)
 
 The examples are taken from my [RPi VPN Router project installation script](https://github.com/saveriomiroddi/rpi_vpn_router/blob/master/install_vpn_router.sh).
 

--- a/_posts/2017-12-23-Shell-scripting-adventures-part-3.md
+++ b/_posts/2017-12-23-Shell-scripting-adventures-part-3.md
@@ -8,18 +8,18 @@ This is the Part 3 (of 5) of the shell scripting adventures, introduced in a [pr
 
 The following subjects are described in this part:
 
-- [Introduction to Whiptail](#introduction-to-whiptail)
-- [Widgets, with snippets](#widgets-with-snippets)
-  - [Message box](#message-box)
-  - [Yes/no box](#yesno-box)
-  - [Gauge](#gauge)
-  - [Radio list](#radio-list)
-- [Other widgets](#other-widgets)
-  - [Input box](#input-box)
-  - [Text box](#text-box)
-  - [Password box](#password-box)
-  - [Menus](#menus)
-  - [Check list](#check-list)
+- [Introduction to Whiptail](/Shell-scripting-adventures-part-3#introduction-to-whiptail)
+- [Widgets, with snippets](/Shell-scripting-adventures-part-3#widgets-with-snippets)
+  - [Message box](/Shell-scripting-adventures-part-3#message-box)
+  - [Yes/no box](/Shell-scripting-adventures-part-3#yesno-box)
+  - [Gauge](/Shell-scripting-adventures-part-3#gauge)
+  - [Radio list](/Shell-scripting-adventures-part-3#radio-list)
+- [Other widgets](/Shell-scripting-adventures-part-3#other-widgets)
+  - [Input box](/Shell-scripting-adventures-part-3#input-box)
+  - [Text box](/Shell-scripting-adventures-part-3#text-box)
+  - [Password box](/Shell-scripting-adventures-part-3#password-box)
+  - [Menus](/Shell-scripting-adventures-part-3#menus)
+  - [Check list](/Shell-scripting-adventures-part-3#check-list)
 
 Since Whiptail is simple to use, the objective of this post is rather to show some useful code snippets/patterns.
 


### PR DESCRIPTION
The links worked from the root page, but not from the article page.

Closes #26