### PR TITLE
Add bookshelf support code, and tweak bookshelf.css to fit the layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ collections:
   tags:
     output: true
     permalink: /tag/:name/
+  books: {}
 
 defaults:
   -

--- a/bookshelf.md
+++ b/bookshelf.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Bookshelf
+permalink: /bookshelf/
+---
+
+{% comment %}
+
+Add files under `_books`, in the format:
+
+---
+new: true
+cover: /images/books/beginning_cpp_though_game_programming_4th_ed.jpg
+description: A fun book to start C++ with; covers the language essentials with consistent progression, and uses example games that are simple enough to be thoroughly analyzed.
+completed: 2019-01-07
+---
+
+Optionally, `cover_width` can be used to fit larger books (the height will stay constant, though).
+
+{% endcomment %}
+
+<link rel="stylesheet" href="/css/bookshelf.css">
+
+{% assign sorted_books = site.books | sort: 'completed' | reverse %}
+{% for book in sorted_books %}
+<ul class="bookshelf">
+  <li class="bookshelf-book">
+   {% if book.new %}
+    <div class="ribbon-new">
+      <div>New</div>
+    </div>
+   {% endif %}
+    <img src="{{ book.cover }}"
+    {% if book.cover_width %}
+      width="{{ book.cover_width }}"
+    {% endif %}
+    />
+    <div class="bookshelf-caption bottom-to-top">
+      <p>{{ book.description }}</p>
+    </div>
+  </li>
+</ul>
+{% endfor %}
+
+<div style="clear: left"></div>

--- a/css/bookshelf.css
+++ b/css/bookshelf.css
@@ -1,12 +1,14 @@
-/* From https://codepen.io/samurai-ka/pen/vEjJy */
+/* Original from https://codepen.io/samurai-ka/pen/vEjJy */
+
+.bookshelf {
+  overflow:auto;
+  float:left;
+}
 
 /*Bookshelf Bookelement*/
 .bookshelf-book {
   list-style-type:none;
-  float:left;
-  margin:10px;
-
-  height:300px;
+  height:275px;
   -webkit-box-shadow: 0px 0px 12px rgba(0,0,0,0.5);
   -moz-box-shadow:    0px 0px 12px rgba(0,0,0,0.5);
   box-shadow:         0px 0px 12px rgba(0,0,0,0.5);
@@ -56,6 +58,7 @@
 
 /*Bookshelf Bookelement caption*/
 .bookshelf-caption {
+  font: 16px sans-serif;
   background-color:#000;
   color:#fff;
   opacity: 0.8;

--- a/css/bookshelf.css
+++ b/css/bookshelf.css
@@ -1,0 +1,92 @@
+/* From https://codepen.io/samurai-ka/pen/vEjJy */
+
+/*Bookshelf Bookelement*/
+.bookshelf-book {
+  list-style-type:none;
+  float:left;
+  margin:10px;
+
+  height:300px;
+  -webkit-box-shadow: 0px 0px 12px rgba(0,0,0,0.5);
+  -moz-box-shadow:    0px 0px 12px rgba(0,0,0,0.5);
+  box-shadow:         0px 0px 12px rgba(0,0,0,0.5);
+  position:relative;
+  overflow:hidden;
+  -webkit-animation: trans 2s;
+  animation: trans 2s;
+}
+.bookshelf-book img {
+  height:100%;
+}
+
+/*Bookshelf Bookelement ribbon*/
+.ribbon-new {
+  width: 100px;
+  height: 100px;
+  overflow: hidden;
+  position: absolute;
+}
+.ribbon-new > div {
+  font: bold 15px sans-serif;
+  color: #333;
+  text-align: center;
+  text-shadow: rgba(255,255,255,0.5) 0px 1px 0px;
+  -webkit-transform: rotate(-45deg);
+  -moz-transform:    rotate(-45deg);
+  -ms-transform:     rotate(-45deg);
+  -o-transform:      rotate(-45deg);
+  position: relative;
+  padding: 7px 0;
+  left: -30px;
+  top: 15px;
+  width: 120px;
+  background-color: #66BA59;
+  background: #c9de96;
+  background: -webkit-linear-gradient(top,  #c9de96 0%,#66ba59 100%);
+  background:        -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c9de96), color-stop(100%,#66ba59));
+  background:    -moz-linear-gradient(top,  #c9de96 0%, #66ba59 100%);
+  background:      -o-linear-gradient(top,  #c9de96 0%,#66ba59 100%);
+  background:     -ms-linear-gradient(top,  #c9de96 0%,#66ba59 100%);
+  background:         linear-gradient(to bottom,  #c9de96 0%,#66ba59 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c9de96', endColorstr='#66ba59',GradientType=0 );
+  -webkit-box-shadow: 0px 0px 3px rgba(0,0,0,0.3);
+  -moz-box-shadow:    0px 0px 3px rgba(0,0,0,0.3);
+  box-shadow:         0px 0px 3px rgba(0,0,0,0.3);
+}
+
+/*Bookshelf Bookelement caption*/
+.bookshelf-caption {
+  background-color:#000;
+  color:#fff;
+  opacity: 0.8;
+  filter: alpha(opacity=80);
+  position:absolute;
+  height:300px;
+  padding:10px;
+}
+.bottom-to-top {
+  top:100%;
+ }
+.bookshelf-book:hover .bottom-to-top {
+  top:0%;
+  transition: all 0.5s ease;
+  -webkit-transition: all 0.5 ease;
+}
+
+/*Animation*/
+@-webkit-keyframes trans {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes trans {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Make it easy to add books, via YAML entries under `_books`.

The CSS tweak is not exact:

- only one shadow per book is left (on the left)
- the margin between books is bigger
- wide covers can have only the width set

but that's ok (at least for now).