### PR TITLE
Add jekyll-redirect-from plugin to Jekyll configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -93,6 +93,7 @@ plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 # Exclude these files from your production _site
 exclude:


### PR DESCRIPTION
The plugin is currently needed to add a redirect to a page that has been renamed.