### PR TITLE
PPA article: add redirect from old page, which doesn't exist anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem "jekyll"
+gem "jekyll-redirect-from"
 gem "jekyll-sitemap"
 gem "jekyll-feed"
 gem "jekyll-seo-tag"

--- a/_config.yml
+++ b/_config.yml
@@ -93,6 +93,7 @@ plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 # Exclude these files from your production _site
 exclude:

--- a/_posts/2018-05-03-Building-a-debian-deb-source-package-and-publishing-it-on-an-ubuntu-ppa.md
+++ b/_posts/2018-05-03-Building-a-debian-deb-source-package-and-publishing-it-on-an-ubuntu-ppa.md
@@ -2,7 +2,9 @@
 layout: post
 title: Building a Debian (`.deb`) source package, and publishing it on an Ubuntu PPA
 tags: [c,distribution,linux,packaging,sysadmin,ubuntu]
-last_modified_at: 2019-07-03 12:03:00
+last_modified_at: 2019-07-04 13:54:00
+redirect_from:
+- /Building-a-debian-deb-source-package-and-publishing-it-on-an-ubuntu-ppa-part-1/
 ---
 
 Although the concepts involved in preparing a Debian (`.deb`) source package and publishing it on an Ubuntu PPA are simple, due to the many moving parts involved, it's not easy to find a single source of information.


### PR DESCRIPTION
Deleting it was a mistake, since there are evidently links to it around the web.