### PR TITLE
Slicing array with AWK article: remove `getline()` footnote

### DIFF
--- a/_posts/2019-08-26-How-to-print-the-last-n-fields-or-slice-an-array-with-awk.md
+++ b/_posts/2019-08-26-How-to-print-the-last-n-fields-or-slice-an-array-with-awk.md
@@ -137,7 +137,7 @@ and lo and behold, this is going to be the content of the clipboard:
 
 As an engineer, I'm not really concerned with what I use, rather, with what's the best[²](#footnote02) approach to a given job; in this case, I require compactness, as long as readability is sacrificed, at most, only a little.
 
-Personally, I consider consolidating as many use cases/requirements as possible into a single tool/service, a significant engineering principle. In this area, I found Perl a very successful tool[³](#footnote03)).
+Personally, I consider consolidating as many use cases/requirements as possible into a single tool/service, a significant engineering principle. In this area, I found Perl a very successful tool.
 
 Enjoy effective and efficient text processing!
 
@@ -145,4 +145,3 @@ Enjoy effective and efficient text processing!
 
 <a name="footnote01">¹</a>: `-1` actually addresses the last field, but only when the first parameter in the range is also negative, e.g. `[-3..-1]`.<br/>
 <a name="footnote02">²</a>: "Best" of course, has a different meaning based on the context.<br/>
-<a name="footnote03">³</a>: with the notable exception of `getline()`; this is quite irritating.<br/>


### PR DESCRIPTION
A similar API exists also in Perl, making the consideration wrong.