### PR TITLE
Add `temp` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 package.json
 .ruby-gemset
 .ruby-version
+
+# Customization(s)
+/temp


### PR DESCRIPTION
It's convenient to have a directory where work files can be added.