### PR TITLE
Sync gem versions with Github Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # See https://pages.github.com/versions.
 #
 gem "jekyll",               '~> 3.8.7'
-gem "jekyll-redirect-from", '~> 0.15.0'
-gem "jekyll-sitemap",       '~> 1.4.0'
 gem "jekyll-feed",          '~> 0.13.0'
+gem "jekyll-redirect-from", '~> 0.15.0'
 gem "jekyll-seo-tag",       '~> 2.6.1'
+gem "jekyll-sitemap",       '~> 1.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
-gem "jekyll"
-gem "jekyll-redirect-from"
-gem "jekyll-sitemap"
-gem "jekyll-feed"
-gem "jekyll-seo-tag"
+# See https://pages.github.com/versions.
+#
+gem "jekyll",               '~> 3.8.7'
+gem "jekyll-redirect-from", '~> 0.15.0'
+gem "jekyll-sitemap",       '~> 1.4.0'
+gem "jekyll-feed",          '~> 0.13.0'
+gem "jekyll-seo-tag",       '~> 2.6.1'


### PR DESCRIPTION
In addition to be a good practice, it also fixes some mistaken deprecations of the previous version, like:

    Deprecation: A call to '{% post_url _posts/2020-02-27-Considerations-review-of-h2-n2-rpi4-in-particular-as-home-server %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.