### PR TITLE
Bookshelf: fix shadows

### DIFF
--- a/css/bookshelf.css
+++ b/css/bookshelf.css
@@ -1,14 +1,14 @@
 /* Original from https://codepen.io/samurai-ka/pen/vEjJy */
 
-.bookshelf {
-  overflow:auto;
-  float:left;
-}
-
 /*Bookshelf Bookelement*/
+.bookshelf{
+  padding-left: 0px;
+}
 .bookshelf-book {
   list-style-type:none;
-  height:275px;
+  float:left;
+  margin:10px;
+  height:300px;
   -webkit-box-shadow: 0px 0px 12px rgba(0,0,0,0.5);
   -moz-box-shadow:    0px 0px 12px rgba(0,0,0,0.5);
   box-shadow:         0px 0px 12px rgba(0,0,0,0.5);
@@ -58,7 +58,6 @@
 
 /*Bookshelf Bookelement caption*/
 .bookshelf-caption {
-  font: 16px sans-serif;
   background-color:#000;
   color:#fff;
   opacity: 0.8;
@@ -69,7 +68,7 @@
 }
 .bottom-to-top {
   top:100%;
- }
+}
 .bookshelf-book:hover .bottom-to-top {
   top:0%;
   transition: all 0.5s ease;


### PR DESCRIPTION
Shadows now show on each side of the book(s). This was a known issue - see commit 3b80d8b9.

Closes #153.