### PR TITLE
Remove article-specific meta/data from bookshelf page

### DIFF
--- a/_layouts/bookshelf.html
+++ b/_layouts/bookshelf.html
@@ -4,12 +4,6 @@ layout: default
 
 <h1>{{ page.title }}</h1>
 
-<div class="date" style="display:inline;">
-  {{ page.date | date: "%B %e, %Y" }} -
-</div>
-
-Tags: {% include tags_list.html filter=page.tags %}
-
 {{ content }}
 
 {% include share-bar.html %}


### PR DESCRIPTION
The page date is a straight bug, while the tags are just out of place.