### PR TITLE
Correct post filenames (underscores to hyphens)

### DIFF
--- a/_posts/2020-05-23-Small-sending-the-display-to-standby-on-mate-gnome-2-desktops.md
+++ b/_posts/2020-05-23-Small-sending-the-display-to-standby-on-mate-gnome-2-desktops.md
@@ -9,8 +9,8 @@ Sometimes, I want to send my display to standby, rather than the entire system. 
 This short article describes how to accomplish this task.
 
 Content:
-- [Sending the screen to standby via commandline, and the problems](/Small_sending_the_display_to_standby_on_mate_gnome_2_desktops#sending-the-screen-to-standby-via-commandline-and-the-problems)
-- [The solution](/Small_sending_the_display_to_standby_on_mate_gnome_2_desktops#the-solution)
+- [Sending the screen to standby via commandline, and the problems](/Small-sending-the-display-to-standby-on-mate-gnome-2-desktops#sending-the-screen-to-standby-via-commandline-and-the-problems)
+- [The solution](/Small-sending-the-display-to-standby-on-mate-gnome-2-desktops#the-solution)
 
 ## Sending the screen to standby via commandline, and the problems
 

--- a/_posts/2021-01-06-Linux-associating-file-types-to-applications.md
+++ b/_posts/2021-01-06-Linux-associating-file-types-to-applications.md
@@ -10,13 +10,13 @@ Some people may still have a troubled experiences while doing so; some others ma
 
 Content:
 
-- [Introduction](/Linux-associating_file_types_to_applications#introduction)
-- [Procedure](/Linux-associating_file_types_to_applications#procedure)
-  - [Finding the desktop file](/Linux-associating_file_types_to_applications#finding-the-desktop-file)
-  - [Finding the MIME type](/Linux-associating_file_types_to_applications#finding-the-mime-type)
-  - [Registering the association](/Linux-associating_file_types_to_applications#registering-the-association)
-- [Association by extension](/Linux-associating_file_types_to_applications#association-by-extension)
-- [Conclusion](/Linux-associating_file_types_to_applications#conclusion)
+- [Introduction](/Linux-associating-file-types-to-applications#introduction)
+- [Procedure](/Linux-associating-file-types-to-applications#procedure)
+  - [Finding the desktop file](/Linux-associating-file-types-to-applications#finding-the-desktop-file)
+  - [Finding the MIME type](/Linux-associating-file-types-to-applications#finding-the-mime-type)
+  - [Registering the association](/Linux-associating-file-types-to-applications#registering-the-association)
+- [Association by extension](/Linux-associating-file-types-to-applications#association-by-extension)
+- [Conclusion](/Linux-associating-file-types-to-applications#conclusion)
 
 ## Introduction
 

--- a/_posts/2021-01-11-Quick-riscv-cross-compilation-and-emulation.md
+++ b/_posts/2021-01-11-Quick-riscv-cross-compilation-and-emulation.md
@@ -12,16 +12,16 @@ I'll also show how to configure the QEMU disk image, and a few useful related fu
 
 Content:
 
-- [Introduction to the tooling options](/Quick_riscv_cross_compilation_and_emulation#introduction-to-the-tooling-options)
-- [Setup](/Quick_riscv_cross_compilation_and_emulation#setup)
-  - [Preliminary steps](/Quick_riscv_cross_compilation_and_emulation#preliminary-steps)
-  - [Building the toolchain](/Quick_riscv_cross_compilation_and_emulation#building-the-toolchain)
-  - [Building zlib and pigz](/Quick_riscv_cross_compilation_and_emulation#building-zlib-and-pigz)
-  - [Downloading and preparing the Fedora RISC-V image](/Quick_riscv_cross_compilation_and_emulation#downloading-and-preparing-the-fedora-risc-v-image)
-  - [Installing QEMU](/Quick_riscv_cross_compilation_and_emulation#installing-qemu)
-- [Execution!](/Quick_riscv_cross_compilation_and_emulation#execution)
-- [Conclusion](/Quick_riscv_cross_compilation_and_emulation#conclusion)
-- [Footnotes](/Quick_riscv_cross_compilation_and_emulation#footnotes)
+- [Introduction to the tooling options](/Quick-riscv-cross-compilation-and-emulation#introduction-to-the-tooling-options)
+- [Setup](/Quick-riscv-cross-compilation-and-emulation#setup)
+  - [Preliminary steps](/Quick-riscv-cross-compilation-and-emulation#preliminary-steps)
+  - [Building the toolchain](/Quick-riscv-cross-compilation-and-emulation#building-the-toolchain)
+  - [Building zlib and pigz](/Quick-riscv-cross-compilation-and-emulation#building-zlib-and-pigz)
+  - [Downloading and preparing the Fedora RISC-V image](/Quick-riscv-cross-compilation-and-emulation#downloading-and-preparing-the-fedora-risc-v-image)
+  - [Installing QEMU](/Quick-riscv-cross-compilation-and-emulation#installing-qemu)
+- [Execution!](/Quick-riscv-cross-compilation-and-emulation#execution)
+- [Conclusion](/Quick-riscv-cross-compilation-and-emulation#conclusion)
+- [Footnotes](/Quick-riscv-cross-compilation-and-emulation#footnotes)
 
 ## Introduction to the tooling options
 


### PR DESCRIPTION
Post filenames should not use underscore as separators, instead, hyphens. Hopefully, this is what's causing the last post (RISC-V) not being indexed on Google.