### PR TITLE
Fix bookshelf books popup shadow

### DIFF
--- a/css/bookshelf.css
+++ b/css/bookshelf.css
@@ -66,6 +66,7 @@
   position:absolute;
   height:300px;
   padding:10px;
+  width: 100%;
 }
 .bottom-to-top {
   top:100%;


### PR DESCRIPTION
For books with (very) short text, the shadow was narrower than the book.