### PR TITLE
Disable Disqus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ footer-links:
 
 # Enter your Disqus shortname (not your username) to enable commenting on posts
 # You can find your shortname on the Settings page of your Disqus account
-disqus: saveriomiroddi
+#disqus: saveriomiroddi
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics: UA-106009737-1


### PR DESCRIPTION
It can be ok to display ads, but it's not ok to display Taboola's trash.